### PR TITLE
Display last chars, instead of first chars on transfer tickets page

### DIFF
--- a/src/Tickets/transferTickets.js
+++ b/src/Tickets/transferTickets.js
@@ -307,7 +307,7 @@ export default class TransferTickets extends Component {
                         {name}
                       </Text>
                       <Text style={ticketStyles.ticketHolderSubheader}>
-                        {id.slice(-8)}
+                        #{id.slice(-8)}
                       </Text>
                     </View>
                   </View>

--- a/src/Tickets/transferTickets.js
+++ b/src/Tickets/transferTickets.js
@@ -307,7 +307,7 @@ export default class TransferTickets extends Component {
                         {name}
                       </Text>
                       <Text style={ticketStyles.ticketHolderSubheader}>
-                        {id.substring(0, 8)}
+                        {id.slice(-8)}
                       </Text>
                     </View>
                   </View>


### PR DESCRIPTION
@Krakaw 
This pull request fixes  [issue#71](https://github.com/big-neon/bn-mobile-react/issues/71)