### PR TITLE
Smaller padding on badge so > icon fits, and remove unussed imports

### DIFF
--- a/src/Events/event_card.js
+++ b/src/Events/event_card.js
@@ -93,11 +93,6 @@ export default class EventsIndex extends Component {
                     />
                   </View>
                 </TouchableHighlight>
-                <View style={styles.avatarContainer}>
-                  {
-                    null // event.avatarImages.map((source, key) => <Image style={styles.avatarSmall} source={source} key={key} />)}
-                  }
-                </View>
               </View>
               {this.priceTag}
             </View>

--- a/src/styles/account/accountStyles.js
+++ b/src/styles/account/accountStyles.js
@@ -4,9 +4,7 @@ import {
   sectionHeaderColor,
   white,
   borderColor,
-  containerDarkColor,
   disabledHeaderColor,
-  disabledColor,
   globalFontSizeSmaller,
   globalFontSizeSmall,
   globalFontSize,
@@ -14,15 +12,12 @@ import {
   globalFontSizeLargest,
   globalFontRegular,
   globalFontMedium,
-  globalPaddingLarge,
-  globalPaddingMedium,
   globalPadding,
   globalPaddingSmall,
   globalPaddingTiny,
   globalMarginSmall,
 } from '../shared/sharedStyles'
 import {StyleSheet, Dimensions, Platform} from 'react-native'
-const fullHeight = Dimensions.get('window').height
 const fullWidth = Dimensions.get('window').width
 
 export const whiteTransparent = 'rgba(255, 255, 255, 0.8)'

--- a/src/styles/account/doormanStyles.js
+++ b/src/styles/account/doormanStyles.js
@@ -10,15 +10,12 @@ import {
   globalFontSizeSmaller,
   globalFontSizeSmall,
   globalFontSizeLarge,
-  globalPaddingMedium,
   globalPadding,
   globalPaddingSmall,
   globalPaddingTiny,
-  globalMargin,
   globalMarginSmall,
 } from '../shared/sharedStyles'
-import {StyleSheet, Dimensions, Platform} from 'react-native'
-const fullHeight = Dimensions.get('window').height
+import {StyleSheet, Dimensions} from 'react-native'
 const fullWidth = Dimensions.get('window').width
 
 export const whiteTransparent = 'rgba(255, 255, 255, 0.8)'
@@ -104,7 +101,7 @@ const DoormanStyles = {
     borderBottomRightRadius: 8,
     borderTopLeftRadius: 8,
     borderTopRightRadius: 8,
-    marginLeft: globalMargin,
+    marginLeft: globalMarginSmall,
   },
   ticketPurchasedBadgeWrapper: {
     backgroundColor: badgeSuccess,

--- a/src/styles/account/eventManagerStyles.js
+++ b/src/styles/account/eventManagerStyles.js
@@ -11,13 +11,11 @@ import {
   globalFontSize,
   globalPadding,
   globalPaddingSmall,
-  globalPaddingTiny,
   globalMargin,
   globalMarginSmall,
 } from '../shared/sharedStyles'
-import {StyleSheet, Dimensions, Platform} from 'react-native'
-const fullHeight = Dimensions.get('window').height
-const fullWidth = Dimensions.get('window').width
+import {StyleSheet} from 'react-native'
+
 
 const EventManagerStyles = {
   // ROW STYLES

--- a/src/styles/account/eventScannerStyles.js
+++ b/src/styles/account/eventScannerStyles.js
@@ -15,13 +15,11 @@ import {
   globalFontSizeJumbo,
   globalFontSemiBold,
   globalFontRegular,
-  globalPaddingTiny,
   globalPaddingSmall,
   globalPadding,
   globalPaddingLarge,
-  globalMargin,
 } from '../shared/sharedStyles'
-import {StyleSheet, Dimensions, Platform} from 'react-native'
+import {StyleSheet, Dimensions} from 'react-native'
 const fullHeight = Dimensions.get('window').height
 const fullWidth = Dimensions.get('window').width
 

--- a/src/styles/account/notificationStyles.js
+++ b/src/styles/account/notificationStyles.js
@@ -1,21 +1,14 @@
 import {
-  textColor,
   sectionHeaderColor,
   white,
   borderColor,
-  containerDarkColor,
-  disabledHeaderColor,
   globalFontRegular,
-  globalFontMedium,
   globalFontSizeSmall,
-  globalPaddingLarge,
-  globalPaddingMedium,
   globalPadding,
   globalPaddingSmall,
-  globalPaddingTiny,
   globalMarginSmall,
 } from '../shared/sharedStyles'
-import {StyleSheet, Dimensions, Platform} from 'react-native'
+import {StyleSheet, Dimensions} from 'react-native'
 const fullHeight = Dimensions.get('window').height
 const fullWidth = Dimensions.get('window').width
 

--- a/src/styles/account/orderHistoryStyles.js
+++ b/src/styles/account/orderHistoryStyles.js
@@ -8,7 +8,7 @@ import {
   globalPaddingSmall,
   globalPaddingTiny,
 } from '../shared/sharedStyles'
-import {StyleSheet, Dimensions, Platform} from 'react-native'
+import {StyleSheet} from 'react-native'
 
 const OrderHistoryStyles = {
   row: {


### PR DESCRIPTION
@simple-taskic 
Pull request for issue #80 
I have tested this on android emulator following specification of this phone (Samsung S7 Edge). The `>` icon is was visible, but I couldn't test in on real phone.