### PR TITLE
Ignore 409 responses when adding a push notification token

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -47,6 +47,10 @@ export async function registerPushTokenIfPermitted() {
       await savePushToken(token)
     }
   } catch (error) {
-    console.warn(`Unable to get notification token. Error: ${error.message}`)
+    if (error && error.response && error.response.status === 409) {
+      console.log(`This device has already stored the token.`);
+    } else {
+      console.warn(`Unable to get notification token. Error: ${error.message}`)
+    }
   }
 }


### PR DESCRIPTION
The server responds with a 409 if the token already exists.