### PR TITLE
Fix crash when transferring the last ticket

### DIFF
--- a/src/Tickets/transferTickets.js
+++ b/src/Tickets/transferTickets.js
@@ -173,7 +173,11 @@ export default class TransferTickets extends Component {
       },
     } = this.props
 
-    return ticketsForEvent(activeTab, eventId).tickets
+    const ticketContainer = ticketsForEvent(activeTab, eventId)
+    if (ticketContainer && ticketContainer.tickets) {
+      return ticketContainer.tickets
+    }
+    return []
   }
 
   get firstName() {


### PR DESCRIPTION
The application was trying to render the "Add Recipient" form without any tickets. This is a quick one to get the fix in ASAP. The way I see it, there are two things which we should follow up on:
1. We should get this right at the state provider level. I didn't want to fiddle with that now in order to not break other call sites, but you can see workarounds similar to the one I've used [elsewhere](https://github.com/big-neon/bn-mobile-react/blob/91af08279aa492a4d0016226e7132f437c0b4671/src/Tickets/showEventTickets.js#L91-L97).
1. For this particular form, I don't think we should bother rendering an empty one after the transfer, since a redirection triggers at the same time anyway.