### PR TITLE
Added a debounce to the events search

### DIFF
--- a/src/Events/search.js
+++ b/src/Events/search.js
@@ -93,6 +93,7 @@ function SuggestedSearches({ searchText, events, navigate }) {
 }
 
 export default class EventSearch extends Component {
+  debounce = false;
   get events() {
     return this.props.store.state.events
   }
@@ -105,9 +106,12 @@ export default class EventSearch extends Component {
     }
   }
 
-  updateSearchText = async (text) => {
-    await this.props.store.setQuery(text)
-    this.searchEvents()
+  updateSearchText = (text) => {
+    clearTimeout(this.debounce);
+    this.props.store.setQuery(text)
+    this.debounce = setTimeout(async() => {
+      this.searchEvents()
+    }, 250)
   }
 
   shouldShowResults() {

--- a/src/Events/search.js
+++ b/src/Events/search.js
@@ -94,6 +94,10 @@ function SuggestedSearches({ searchText, events, navigate }) {
 
 export default class EventSearch extends Component {
   debounce = 0;
+  state = {
+    localQuery: ''
+  };
+
   get events() {
     return this.props.store.state.events
   }
@@ -108,20 +112,21 @@ export default class EventSearch extends Component {
 
   updateSearchText = (text) => {
     clearTimeout(this.debounce);
-    this.props.store.setQuery(text)
+    this.setState({localQuery: text});
     this.debounce = setTimeout(async() => {
+      await this.props.store.setQuery(text)
       this.searchEvents()
     }, 250)
   }
 
   shouldShowResults() {
-    const { query } = this.props.store.state
+    const { localQuery } = this.state
 
-    return query.length >= 3
+    return localQuery.length >= 3
   }
 
   render() {
-    const { query } = this.props.store.state
+    const { localQuery } = this.state
     const showResults = this.shouldShowResults()
 
     return (
@@ -136,7 +141,7 @@ export default class EventSearch extends Component {
             placeholder="Search artists, shows, venues..."
             searchIcon={{ size: 24 }}
             underlineColorAndroid="transparent"
-            value={query}
+            value={localQuery}
             onChangeText={this.updateSearchText}
           />
         </View>
@@ -144,12 +149,12 @@ export default class EventSearch extends Component {
         {showResults && (
           <React.Fragment>
             <SuggestedSearches
-              searchText={query}
+              searchText={localQuery}
               events={this.events}
               navigate={this.props.navigate}
             />
             <Text style={styles.sectionHeader}>
-              {`Search Results for "${query}"`}
+              {`Search Results for "${localQuery}"`}
             </Text>
           </React.Fragment>
         )}

--- a/src/Events/search.js
+++ b/src/Events/search.js
@@ -93,7 +93,7 @@ function SuggestedSearches({ searchText, events, navigate }) {
 }
 
 export default class EventSearch extends Component {
-  debounce = false;
+  debounce = 0;
   get events() {
     return this.props.store.state.events
   }


### PR DESCRIPTION
The events search was waiting for the setState to return, then immediately triggering the search function. I have removed the await from the setState for faster rendering time and added a 250ms delay for the server search to start.