### PR TITLE
Add formatting to HTML event descriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8005,7 +8005,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
       "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
-      "dev": true,
       "requires": {
         "domelementtype": "^1.3.0",
         "entities": "^1.1.1"
@@ -8025,8 +8024,7 @@
     "domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domexception": {
       "version": "1.0.1",
@@ -8041,7 +8039,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-      "dev": true,
       "requires": {
         "domelementtype": "1"
       }
@@ -8050,7 +8047,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
@@ -8194,8 +8190,7 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "envinfo": {
       "version": "5.12.1",
@@ -11639,8 +11634,7 @@
     "html-entities": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
-      "dev": true
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
     },
     "html-loader": {
       "version": "0.5.5",
@@ -11697,7 +11691,6 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
       "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-      "dev": true,
       "requires": {
         "domelementtype": "^1.3.1",
         "domhandler": "^2.3.0",
@@ -11711,7 +11704,6 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
           "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -12200,8 +12192,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -20021,6 +20012,34 @@
         "create-react-class": "^15.6.0",
         "prop-types": "^15.5.10",
         "qr.js": "0.0.0"
+      }
+    },
+    "react-native-render-html": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/react-native-render-html/-/react-native-render-html-4.1.2.tgz",
+      "integrity": "sha512-lIW7GfNCsqOzdv0hxiZms24uC9Hu8hqufMyD4FBjfs8HSc4pUKnvBgOljiqEXmjGhDEJM6oY7QGglAV0hL69bQ==",
+      "requires": {
+        "buffer": "^4.5.1",
+        "events": "^1.1.0",
+        "html-entities": "^1.2.0",
+        "htmlparser2": "^3.10.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        }
       }
     },
     "react-native-safe-area-view": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-native-loading-spinner-overlay": "^1.0.1",
     "react-native-modal-dropdown": "^0.6.2",
     "react-native-qrcode": "^0.2.7",
+    "react-native-render-html": "4.1.2",
     "react-native-size-matters": "^0.2.1",
     "react-native-snap-carousel": "^3.8.0",
     "react-native-swipe-list-view": "^2.0.1",

--- a/src/Events/details.js
+++ b/src/Events/details.js
@@ -1,12 +1,13 @@
-import React, { Component } from 'react'
-import PropTypes from 'prop-types'
-import { Text, Platform, View, Linking, TouchableHighlight } from 'react-native'
-import Icon from 'react-native-vector-icons/MaterialIcons'
-import SharedStyles from '../styles/shared/sharedStyles'
-import EventDetailsStyles from '../styles/event_details/eventDetailsStyles'
-import { eventDateTimes } from '../time'
 import { map } from 'lodash'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import { Linking, Platform, Text, TouchableHighlight, View } from 'react-native'
+import HTML from 'react-native-render-html'
+import Icon from 'react-native-vector-icons/MaterialIcons'
 import { shareEvent } from '../sharing'
+import EventDetailsStyles from '../styles/event_details/eventDetailsStyles'
+import SharedStyles from '../styles/shared/sharedStyles'
+import { eventDateTimes } from '../time'
 
 /*  eslint-disable camelcase */
 
@@ -219,7 +220,6 @@ export default class Details extends Component {
               </Text>
             </View>
             <Text style={eventDetailsStyles.bodyText}>{this.ageLimit}</Text>
-
             <View style={eventDetailsStyles.eventDescriptionHeaderWrapper}>
               <Icon
                 style={eventDetailsStyles.iconEventDescription}
@@ -229,13 +229,68 @@ export default class Details extends Component {
                 EVENT DESCRIPTION
               </Text>
             </View>
-            <Text style={eventDetailsStyles.bodyText}>
-              {event.additional_info}
-            </Text>
+            <View style={eventDetailsStyles.descriptionBodyContainer}>
+              <HTML
+                baseFontStyle={baseFontStyle}
+                listsPrefixesRenderers={listsPrefixesRenderers}
+                tagsStyles={tagsStyles}
+                html={event.additional_info}
+              />
+            </View>
           </View>
         </View>
         <View style={eventDetailsStyles.spacerFooter} />
       </View>
     )
   }
+}
+
+const listsPrefixesRenderers = {
+  ul: () => (
+    <View
+      style={{
+        backgroundColor: '#9da3b4',
+        borderRadius: 4,
+        height: 8,
+        marginRight: 18,
+        marginTop: 8,
+        width: 8,
+      }}
+    />
+  ),
+}
+
+const baseHeaderStyle = {
+  color: '#2c3136',
+  fontFamily: 'tt_commons_demibold',
+  marginTop: 35,
+  marginBottom: 20,
+}
+
+const baseFontStyle = {
+  color: '#3c383f',
+  fontFamily: 'tt_commons_regular',
+  fontSize: 17,
+}
+
+const boldStyle = {
+  fontFamily: 'tt_commons_bold',
+}
+
+const tagsStyles = {
+  h1: {
+    ...baseHeaderStyle,
+    fontSize: 30,
+  },
+  h2: {
+    ...baseHeaderStyle,
+    fontSize: 24,
+  },
+  strong: {
+    ...boldStyle,
+  },
+  u: {
+    ...boldStyle,
+    textDecorationLine: 'none',
+  },
 }

--- a/src/Events/details.js
+++ b/src/Events/details.js
@@ -233,6 +233,7 @@ export default class Details extends Component {
               <HTML
                 baseFontStyle={baseFontStyle}
                 listsPrefixesRenderers={listsPrefixesRenderers}
+                onLinkPress={(_, href) => Linking.openURL(href)}
                 tagsStyles={tagsStyles}
                 html={event.additional_info}
               />
@@ -278,6 +279,11 @@ const boldStyle = {
 }
 
 const tagsStyles = {
+  a: {
+    ...boldStyle,
+    color: '#ff22b2',
+    textDecorationLine: 'none',
+  },
   h1: {
     ...baseHeaderStyle,
     fontSize: 30,

--- a/src/styles/event_details/eventDetailsStyles.js
+++ b/src/styles/event_details/eventDetailsStyles.js
@@ -119,6 +119,10 @@ const EventDetailsStyles = {
   },
 
   // TEXT STYLES
+  descriptionBodyContainer: {
+    paddingBottom: globalPaddingSmall,
+    paddingLeft: globalPadding + globalPaddingTiny,
+  },
   descriptionHeader: {
     color: textColor,
     fontFamily: globalFontSemiBold,


### PR DESCRIPTION
Related to #180.

Here is the [before](https://user-images.githubusercontent.com/10366797/67085031-64378e00-f19e-11e9-9feb-29b2a97b7b66.png) & [after](https://user-images.githubusercontent.com/10366797/67085030-64378e00-f19e-11e9-9177-230517b962d7.png) for HTML event descriptions.

Here is the [before](https://user-images.githubusercontent.com/10366797/67085036-64d02480-f19e-11e9-8dad-1b33b888c72e.png) & [after](https://user-images.githubusercontent.com/10366797/67085033-64378e00-f19e-11e9-92e0-ea34a7b5e00c.png) for plaintext event descriptions.

While the old & new designs are mixed, there will be some weirdness going on. For example, in the HTML version, heading margins with be added to the section title's margin (the section title being "**EVENT DESCRIPTION**" in this case). For plaintext, the updated colors (darker text) will be shown alongside the old colors.