### PR TITLE
Hide the event screen's navigation bar

### DIFF
--- a/src/Events/show.js
+++ b/src/Events/show.js
@@ -77,6 +77,10 @@ export default class EventShow extends Component {
     screenProps: PropTypes.object.isRequired,
   }
 
+  static navigationOptions = {
+    header: null,
+  }
+
   constructor(props) {
     super(props)
 


### PR DESCRIPTION
This works around a crash when navigating to "Home" after adding tickets to the cart.

Navigating back by swiping doesn't trigger the bug.

[Asana task](https://app.asana.com/0/1145761918805786/1146045396993929)