### PR TITLE
Fix warning about accessing view manager configs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11347,11 +11347,6 @@
         }
       }
     },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
-    },
     "handle-thing": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
@@ -19957,14 +19952,13 @@
       }
     },
     "react-native-gesture-handler": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.4.1.tgz",
-      "integrity": "sha512-Ffcs+SbEbkGaal0CClYL+v7A9y4OA5G5lW01qrzjxaqASp5C8BfnWSKuqYKE00s6bLwE5L4xnlHkG0yIxAtbrQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-1.3.0.tgz",
+      "integrity": "sha512-ASRFIXBuKRvqlmwkWJhV8yP2dTpvcqVrLNpd7FKVBFHYWr6SAxjGyO9Ik8w1lAxDhMlRP2IcJ9p9eq5X2WWeLQ==",
       "requires": {
-        "hammerjs": "^2.0.8",
         "hoist-non-react-statics": "^2.3.1",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.7.2"
+        "invariant": "^2.2.2",
+        "prop-types": "^15.5.10"
       },
       "dependencies": {
         "hoist-non-react-statics": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",
     "react-native-circle-checkbox": "^0.1.6",
     "react-native-expo-image-cache": "^4.0.8",
-    "react-native-gesture-handler": "^1.4.1",
+    "react-native-gesture-handler": "1.3.0",
     "react-native-keyboard-aware-scroll-view": "^0.9.1",
     "react-native-loading-spinner-overlay": "^1.0.1",
     "react-native-modal-dropdown": "^0.6.2",


### PR DESCRIPTION
A warning was popping up on every app restart. As per [this issue](https://github.com/kmagiera/react-native-gesture-handler/issues/742), downgrading `react-native-gesture-handler` fixes it.

As far as I understand, `react-native-gesture-handler` is a peer dependency for `react-navigation`. No functionality is affected by this downgrade.